### PR TITLE
require date for Date.today

### DIFF
--- a/foretello_api_v21.gemspec
+++ b/foretello_api_v21.gemspec
@@ -1,4 +1,5 @@
 require File.expand_path('../lib/foretello_api_v21/version', __FILE__)
+require 'date'
 
 Gem::Specification.new do |s|
   s.name        = "foretello_api_v21"


### PR DESCRIPTION
When running rake db:create during a test run today is not defined unless you
require date.
