### PR TITLE
Fix Foreman 1.7 compatability with host subnets

### DIFF
--- a/app/serializers/discovered_host_serializer.rb
+++ b/app/serializers/discovered_host_serializer.rb
@@ -25,7 +25,7 @@ class DiscoveredHostSerializer < ActiveModel::Serializer
   end
 
   def subnet_to_s
-    object.subnet.to_s
+    ""
   end
 
   def is_virtual

--- a/app/serializers/host_base_serializer.rb
+++ b/app/serializers/host_base_serializer.rb
@@ -57,7 +57,7 @@ class HostBaseSerializer < ActiveModel::Serializer
   end
 
   def subnet_to_s
-    object.subnet.to_s
+    ""
   end
 
   def is_virtual


### PR DESCRIPTION
Only managed hosts in foreman 1.7 have subnets. In foreman 1.8, [subnets were moved to Host::Base](https://github.com/theforeman/foreman/commit/43c4bd72e4646cc9b2b4cb0533e84e08825eadda#diff-07cbb99bfdb4bed86ad02486bb5adde2R25) but prior to this, subnets only existed for Host::Managed (via the HostCommon module). Here's the error I'm seeing:

```
2015-12-18 11:28:19 [E] NoMethodError: undefined method `subnet' for #<Host::Base:0x0000001a3953b8>
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/activemodel-3.2.21/lib/active_model/attribute_methods.rb:407:in `method_missing'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/activerecord-3.2.21/lib/active_record/attribute_methods.rb:149:in `method_missing'
/home/dadavis/Projects/foretello_api_v21/app/serializers/host_base_serializer.rb:60:in `subnet_to_s'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/active_model_serializers-0.9.3/lib/active_model/serializer.rb:160:in `block in attributes'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/active_model_serializers-0.9.3/lib/active_model/serializer.rb:159:in `each'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/active_model_serializers-0.9.3/lib/active_model/serializer.rb:159:in `each_with_object'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/active_model_serializers-0.9.3/lib/active_model/serializer.rb:159:in `attributes'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/active_model_serializers-0.9.3/lib/active_model/serializer.rb:284:in `serializable_object'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/active_model_serializers-0.9.3/lib/active_model/serializer.rb:212:in `block in embedded_in_root_associations'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/active_model_serializers-0.9.3/lib/active_model/serializer.rb:200:in `each'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/active_model_serializers-0.9.3/lib/active_model/serializer.rb:200:in `each_with_object'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/active_model_serializers-0.9.3/lib/active_model/serializer.rb:200:in `embedded_in_root_associations'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/active_model_serializers-0.9.3/lib/active_model/serializable.rb:28:in `serializable_data'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/active_model_serializers-0.9.3/lib/active_model/serializable.rb:13:in `block in as_json'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/activesupport-3.2.21/lib/active_support/notifications.rb:123:in `block in instrument'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/activesupport-3.2.21/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/activesupport-3.2.21/lib/active_support/notifications.rb:123:in `instrument'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/active_model_serializers-0.9.3/lib/active_model/serializable.rb:55:in `instrument'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/active_model_serializers-0.9.3/lib/active_model/serializable.rb:10:in `as_json'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/activesupport-3.2.21/lib/active_support/json/encoding.rb:47:in `block in encode'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/activesupport-3.2.21/lib/active_support/json/encoding.rb:77:in `check_for_circular_references'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/activesupport-3.2.21/lib/active_support/json/encoding.rb:46:in `encode'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/activesupport-3.2.21/lib/active_support/json/encoding.rb:31:in `encode'
/home/vagrant/.rvm/gems/ruby-1.9.3-p448/gems/activesupport-3.2.21/lib/active_support/core_ext/object/to_json.rb:16:in `to_json'
```
