### PR TITLE
lock down ams so 0.10.0 doesn't get installed yet

### DIFF
--- a/foretello_api_v21.gemspec
+++ b/foretello_api_v21.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "active_model_serializers", '~> 0.9'
+  s.add_dependency "active_model_serializers", '~> 0.9.3'
   #s.add_dependency "apipie-rails"
 
 end


### PR DESCRIPTION
0.10.0 was released today. travis is trying to use it and tests are failing.
