### PR TITLE
Use processorcount fact for all types of hosts

### DIFF
--- a/app/serializers/host_base_serializer.rb
+++ b/app/serializers/host_base_serializer.rb
@@ -23,11 +23,7 @@ class HostBaseSerializer < ActiveModel::Serializer
   end
 
   def cpus
-    if is_managed
-      object.facts_hash['processorcount']
-    elsif is_discovered
-      object.cpu_count
-    end
+    object.facts_hash['processorcount']
   end
 
   def memory_human_size


### PR DESCRIPTION
- If using cpu_count for discovered hosts, BM machines will only report
  physical CPUs rather than total cores available, underreporting
  processing capacity
